### PR TITLE
Return 0 exit status with --exit if no errors

### DIFF
--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -124,11 +124,11 @@ defmodule Sobelow do
     status =
       case exit_on do
         :high ->
-          if high_count > 0, do: 1
+          if high_count > 0, do: 1, else: 0
         :medium ->
-          if high_count + medium_count > 0, do: 1
+          if high_count + medium_count > 0, do: 1, else: 0
         :low ->
-          if high_count + medium_count + low_count > 0, do: 1
+          if high_count + medium_count + low_count > 0, do: 1, else: 0
         _ -> 0
       end
 


### PR DESCRIPTION
Seems to fix issue #8. Didn't find any tests, which makes me sad.