### PR TITLE
handle dynamically generated functions

### DIFF
--- a/lib/sobelow/utils.ex
+++ b/lib/sobelow/utils.ex
@@ -137,11 +137,11 @@ defmodule Sobelow.Utils do
   end
 
   def finding_file_metadata(filename, fun_name, line_no) do
-    "File: #{filename} - #{handle_fun(fun_name)}:#{line_no}"
+    "File: #{filename} - #{prettify_fun(fun_name)}:#{line_no}"
   end
 
-  defp handle_fun({:unquote, _, [{fn_name, _, _}]}), do: "unquote(#{fn_name})"
-  defp handle_fun(fn_name), do: fn_name
+  defp prettify_fun({:unquote, _, [{fn_name, _, _}]}), do: "unquote(#{fn_name})"
+  defp prettify_fun(fn_name), do: fn_name
 
   def finding_variable(var) do
     "Variable: #{var}"

--- a/lib/sobelow/utils.ex
+++ b/lib/sobelow/utils.ex
@@ -140,7 +140,7 @@ defmodule Sobelow.Utils do
     "File: #{filename} - #{prettify_fun(fun_name)}:#{line_no}"
   end
 
-  defp prettify_fun({:unquote, _, [{fn_name, _, _}]}), do: "unquote(#{fn_name})"
+  defp prettify_fun({:unquote, _, _} = fun), do: Macro.to_string(fun)
   defp prettify_fun(fn_name), do: fn_name
 
   def finding_variable(var) do

--- a/lib/sobelow/utils.ex
+++ b/lib/sobelow/utils.ex
@@ -137,8 +137,11 @@ defmodule Sobelow.Utils do
   end
 
   def finding_file_metadata(filename, fun_name, line_no) do
-    "File: #{filename} - #{fun_name}:#{line_no}"
+    "File: #{filename} - #{handle_fun(fun_name)}:#{line_no}"
   end
+
+  defp handle_fun({:unquote, _, [{fn_name, _, _}]}), do: "unquote(#{fn_name})"
+  defp handle_fun(fn_name), do: fn_name
 
   def finding_variable(var) do
     "Variable: #{var}"


### PR DESCRIPTION
Given dynamically generated function names, sobelow gives an error. The following is obviously a contrived example but should convey the issue

Input code:
```elixir
defmodule A do
  info = [
    name: "samar",
    address: "earth",
  ]

  for {k, v} <- info do
    def unquote(k)(), do: String.to_atom(unquote(v))
  end
end
```

Result of `mix sobelow`:
```
Unsafe `String.to_atom` - Low Confidence
** (Protocol.UndefinedError) protocol String.Chars not implemented for {:unquote, [line: 8], [{:k, [line: 8], nil}]}
    (elixir) lib/string/chars.ex:3: String.Chars.impl_for!/1
    (elixir) lib/string/chars.ex:17: String.Chars.to_string/1
    lib/sobelow/utils.ex:140: Sobelow.Utils.finding_file_metadata/3
    lib/sobelow/utils.ex:118: Sobelow.Utils.print_finding_metadata/9
    (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir) lib/enum.ex:645: Enum.each/2
    (elixir) lib/enum.ex:645: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir) lib/enum.ex:645: Enum.each/2
```

The simplest way I could get around this is by adding this check but if there's anything better, feel free to close this PR