### PR TITLE
CSRF Check

### DIFF
--- a/lib/sobelow/utils.ex
+++ b/lib/sobelow/utils.ex
@@ -601,6 +601,7 @@ defmodule Sobelow.Utils do
   def get_plug_accepts(_), do: false
 
   def get_plug_csrf({:plug, _, [:protect_from_forgery]}), do: true
+  def get_plug_csrf({:plug, _, [:protect_from_forgery, _]}), do: true
   def get_plug_csrf(_), do: false
 
   def parse_accepts([{:<<>>, _, [accepts|_]}, []]), do: String.split(accepts, " ")

--- a/test/config/csrf.exs
+++ b/test/config/csrf.exs
@@ -1,0 +1,23 @@
+defmodule SobelowTest do
+  use ExUnit.Case
+  alias Sobelow.Utils
+  doctest Sobelow.Config.CSRF
+
+  test "checks normal router" do
+  	router = "./test/fixtures/good_router.ex"
+    refute Utils.get_pipelines(router)
+					 |> Enum.any?(&Utils.is_vuln_pipeline/1)
+  end
+
+  test "checks normal router with named session key" do
+  	router = "./test/fixtures/good_router_with_session_key.ex"
+    refute Utils.get_pipelines(router)
+					 |> Enum.any?(&Utils.is_vuln_pipeline/1)
+  end
+
+  test "checks bad router" do
+  	router = "./test/fixtures/bad_router.ex"
+    assert Utils.get_pipelines(router)
+					 |> Enum.any?(&Utils.is_vuln_pipeline/1)
+  end
+end

--- a/test/config/csrf_test.exs
+++ b/test/config/csrf_test.exs
@@ -1,7 +1,6 @@
-defmodule SobelowTest do
+defmodule Sobelow.Config.CSRFTest do
   use ExUnit.Case
   alias Sobelow.Utils
-  doctest Sobelow.Config.CSRF
 
   test "checks normal router" do
   	router = "./test/fixtures/good_router.ex"
@@ -13,6 +12,12 @@ defmodule SobelowTest do
   	router = "./test/fixtures/good_router_with_session_key.ex"
     refute Utils.get_pipelines(router)
 					 |> Enum.any?(&Utils.is_vuln_pipeline/1)
+  end
+
+  test "checks normal router with with" do
+    router = "./test/fixtures/good_router_with_with.ex"
+    refute Utils.get_pipelines(router)
+           |> Enum.any?(&Utils.is_vuln_pipeline/1)
   end
 
   test "checks bad router" do

--- a/test/fixtures/bad_router.ex
+++ b/test/fixtures/bad_router.ex
@@ -1,0 +1,7 @@
+defmodule GoodRouter do
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_flash
+  end
+end

--- a/test/fixtures/bad_router.ex
+++ b/test/fixtures/bad_router.ex
@@ -1,4 +1,5 @@
-defmodule GoodRouter do
+# Router is missing plug :protect_from_forgery
+defmodule BadRouter do
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session

--- a/test/fixtures/good_router.ex
+++ b/test/fixtures/good_router.ex
@@ -1,0 +1,6 @@
+defmodule GoodRouter do
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :protect_from_forgery
+  end
+end

--- a/test/fixtures/good_router_with_session_key.ex
+++ b/test/fixtures/good_router_with_session_key.ex
@@ -1,4 +1,4 @@
-defmodule GoodRouter do
+defmodule GoodRouterWithSessionKey do
   pipeline :browser do
     plug :accepts, ["html"]
     plug :protect_from_forgery, session_key: "_phoenix_csrf_token"

--- a/test/fixtures/good_router_with_session_key.ex
+++ b/test/fixtures/good_router_with_session_key.ex
@@ -1,0 +1,6 @@
+defmodule GoodRouter do
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :protect_from_forgery, session_key: "_phoenix_csrf_token"
+  end
+end

--- a/test/fixtures/good_router_with_with.ex
+++ b/test/fixtures/good_router_with_with.ex
@@ -1,0 +1,6 @@
+defmodule GoodRouterWithWith do
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :protect_from_forgery, with: :clear_session
+  end
+end


### PR DESCRIPTION
According to [Plug docs](https://github.com/elixir-plug/plug/blob/master/lib/plug/csrf_protection.ex#L44-L51), the `:protect_from_forgery` plug accepts the following options:

  ## Options
    * `:session_key` - the name of the key in session to store the token under
    * `:with` - should be one of `:exception` or `:clear_session`. Defaults to
    `:exception`.
      * `:exception` -  for invalid requests, this plug will raise
      `Plug.CSRFProtection.InvalidCSRFTokenError`.
      * `:clear_session` -  for invalid requests, this plug will set an empty
      session for only this request. Also any changes to the session during this
      request will be ignored.

When we ran against our codebase using `:session_key` we got a false error.  This PR adjusts the match in the utlis.ex to allow options.