### PR TITLE
change the router error message to a warning message

### DIFF
--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -259,11 +259,10 @@ defmodule Sobelow do
 
   defp no_router() do
     message = """
-    ERROR: Sobelow cannot find the router. Ensure that this is a Phoenix 
-    application, or use the `--router` flag to specify the router's 
-    location.
+    WARNING: Sobelow cannot find the router. If this is a Phoenix application
+    please use the `--router` flag to specify the router's location.
     """
-    MixIO.error(message)
+    MixIO.info(message)
     ignored = get_env(:ignored)
     Application.put_env(:sobelow, :ignored, ignored ++ ["Config.CSRF", "Config.Headers"])
   end


### PR DESCRIPTION
I was thinking about #17 and it occured to me, that we don't need to get rid of the error messages at all. Maybe if we just change the wording a bit it can still be clear for both phoenix and non-phoenix projects?

__Before__

```
ERROR: Sobelow cannot find the router. Ensure that this is a Phoenix
application, or use the `--router` flag to specify the router's
location.
```

__After__

```
WARNING: Sobelow cannot find the router. If this is a Phoenix application
please use the `--router` flag to specify the router's location.
```

I think this warning makes it clear that sobelow wants to find the router if this is a phoenix application, but it isn't an error. Other applications can proceed normally.

What do you think?