### PR TITLE
Fix log finding of hardcorded secrets

### DIFF
--- a/lib/sobelow/config/secrets.ex
+++ b/lib/sobelow/config/secrets.ex
@@ -72,6 +72,8 @@ defmodule Sobelow.Config.Secrets do
         Sobelow.log_finding(finding, :high)
 
       "txt" ->
+        Sobelow.log_finding(type, :high)
+
         IO.puts(IO.ANSI.red() <> type <> " - High Confidence" <> IO.ANSI.reset())
         IO.puts("File: #{file} - line #{line_no}")
         IO.puts("Type: #{key}")


### PR DESCRIPTION
I had a problem that, when using `--exit Low`, the exit code was `0` when the only issue found was a hardcoded secret. If there was at least one other issue (eg. after removing some ignore options), the exit code was correct, `1`.

This PR fixes that problem.

I couldn't figure out in a timely manner how to add tests for this case, sorry.