### PR TITLE
Do not halt execution on a successful check

### DIFF
--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -163,7 +163,7 @@ defmodule Sobelow do
       end
 
     exit_status = if is_nil(status), do: 0, else: status
-    System.halt(exit_status)
+    if exit_status != 0, do: System.halt(exit_status)
   end
 
   def details() do


### PR DESCRIPTION
Calling `mix sobelow` exit with code 0 on successful verification, this makes it impossible to build call chains. 
E.g., I create mix alias `check`:
```elixir
  defp aliases do
    [
     ...
      check: ["format --check-formatted", "credo --strict", "sobelow --config", "test"]
    ]
  end
```

In this example, tests will never be called, because sobelow always will call an exit.