### PR TITLE
Fix quiet with empty string out

### DIFF
--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -135,6 +135,7 @@ defmodule Sobelow do
   defp print_std_or_file(details) do
     case get_env(:out) do
       nil -> IO.puts(details)
+      "" -> IO.puts(details)
       out -> File.write(out, details)
     end
   end


### PR DESCRIPTION
By default command `mix sobelow --save-config` generate config with `out: ""`. 
In such cases, when `quit: true`, there will be no output for vulnerabilities. 
This leads to false positive results.
PR fixed it. 