### PR TITLE
Utils.get_app_name/1 now understands the mod attr as application name

### DIFF
--- a/test/fixtures/utils/mix.exs
+++ b/test/fixtures/utils/mix.exs
@@ -1,0 +1,10 @@
+defmodule FooBar.Mixfile do
+  use Mix.Project
+
+  @app :foo_bar
+  def project do
+    [
+      app: @app
+    ]
+  end
+end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -1,0 +1,7 @@
+defmodule SobelowTest.UtilsTest do
+  use ExUnit.Case
+
+  test "Utils.get_app_name/1 understands module attributes" do
+    assert Sobelow.Utils.get_app_name("./test/fixtures/utils/mix.exs") == "foo_bar"
+  end
+end


### PR DESCRIPTION
Sometimes the application name is defined via the module attribute:

```elixir
  @app :foo_bar
  def project do
    [
      app: @app
      ...
```

This PR makes _Sobelow_ to understand this application name.