### PR TITLE
Allow for piping into send_download function

### DIFF
--- a/lib/sobelow/traversal/send_download.ex
+++ b/lib/sobelow/traversal/send_download.ex
@@ -30,5 +30,6 @@ defmodule Sobelow.Traversal.SendDownload do
   defp type_binary?([_, {:binary, _}, _]), do: true
   defp type_binary?([_, {:binary, _}]), do: true
   defp type_binary?([{:binary, _}]), do: true
+  defp type_binary?([{:binary, _}, _]), do: true
   defp type_binary?(_), do: false
 end

--- a/test/traversal/send_download_test.exs
+++ b/test/traversal/send_download_test.exs
@@ -37,5 +37,16 @@ defmodule SobelowTest.Traversal.SendDownload do
     {_, ast} = Code.string_to_quoted(func)
 
     refute SendDownload.parse_def(ast) |> is_vuln?
+
+    func = """
+    def index(conn, %{"test" => test}) do
+      conn
+      |> send_download({:binary, test}, filename: "test")
+    end
+    """
+
+    {_, ast} = Code.string_to_quoted(func)
+
+    refute SendDownload.parse_def(ast) |> is_vuln?
   end
 end


### PR DESCRIPTION
Currently the following code flags the vulnerability `Traversal.SendDownload: Directory Traversal in send_download - Medium Confidence`:

```elixir
conn
|> send_download({:binary, test}, filename: "test")
```

but this code does not:

```elixir
send_download(conn, {:binary, test}, filename: "test")
```

We would like both to not be marked as vulnerabilities. 