### PR TITLE
Add recommended combinations of Elixir and Erlang/OTP versions to CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -32,6 +32,7 @@ jobs:
           - elixir: 1.10.x
             otp: 23.0.3
             warnings_as_errors: true
+            check_formatted: true
     env:
       MIX_ENV: test
     steps:
@@ -45,6 +46,8 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get --only test
+      - run: mix format --check-formatted
+        if: matrix.check_formatted
       - run: mix compile --warnings-as-errors
         if: matrix.warnings_as_errors
       - run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,21 +1,50 @@
 name: Elixir CI
 
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
-  build:
-
+  mix_test:
+    name: mix test (Elixir ${{matrix.elixir}} | OTP ${{matrix.otp}})
     runs-on: ubuntu-latest
-
-    container:
-      image: elixir:1.9.1-slim
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - elixir: 1.4.x
+            otp: 18.3.4.11
+          - elixir: 1.5.x
+            otp: 18.3.4.11
+          - elixir: 1.6.x
+            otp: 19.3.6.13
+          - elixir: 1.7.x
+            otp: 19.3.6.13
+          - elixir: 1.8.x
+            otp: 20.3.8.26
+          - elixir: 1.9.x
+            otp: 20.3.8.26
+            warnings_as_errors: true # 1.10 is not enough as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
+          - elixir: 1.10.x
+            otp: 21.3.8.17
+          - elixir: 1.10.x
+            otp: 23.0.3
+            warnings_as_errors: true
+    env:
+      MIX_ENV: test
     steps:
-    - uses: actions/checkout@v1
-    - name: Install Dependencies
-      run: |
-        mix local.rebar --force
-        mix local.hex --force
-        mix deps.get
-    - name: Run Tests
-      run: mix test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+      - name: Install Dependencies
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get --only test
+      - run: mix compile --warnings-as-errors
+        if: matrix.warnings_as_errors
+      - run: mix test

--- a/lib/sobelow/fingerprint.ex
+++ b/lib/sobelow/fingerprint.ex
@@ -1,7 +1,9 @@
 defmodule Sobelow.Fingerprint do
   @moduledoc false
 
-  use Agent
+  if Version.match?(System.build_info().version, ">= 1.5.0") do
+    use Agent
+  end
 
   def start_link() do
     Agent.start_link(fn -> {MapSet.new(), MapSet.new()} end, name: __MODULE__)

--- a/test/fixtures/cswh/good_endpoint_2.ex
+++ b/test/fixtures/cswh/good_endpoint_2.ex
@@ -1,5 +1,8 @@
 defmodule PhoenixWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :phoenix
 
-  socket("/socket", PhoenixInternalsWeb.UserSocket, websocket: [check_origin: true], longpoll: false)
+  socket("/socket", PhoenixInternalsWeb.UserSocket,
+    websocket: [check_origin: true],
+    longpoll: false
+  )
 end


### PR DESCRIPTION
This pull request makes sure all recommended Elixir and Erlang/OTP combinations are run on CI.

Quoting José Valim:
> I would still advise folks to go with:
> * For each Elixir version, add a run with earliest supported Erlang/OTP
> * For the last Elixir version, also test the latest supported Erlang/OTP

Please refer to the original discussion on https://github.com/dashbitco/broadway/pull/188 for the full rationale.

Additional functionality: make sure there are no compilation warnings and checks formatting.

In case one wonders why not use `otp: N.x` for OTP as well as for Elixir, the reason is the following: [actions/setup-elixir v1.4.0 uses semantic version resolution for Erlang/OTP](https://github.com/actions/setup-elixir/blob/v1.4.0/src/setup-elixir.js#L81), but Erlang/OTP version scheme does not follow SemVer and ["In general, versions can have more than three parts."](https://erlang.org/doc/system_principles/versions.html#order-of-versions), so [`otp: 19.x` resolves to 19.3.6](https://github.com/adrianomitre/phoenix_pubsub/runs/980417508?check_suite_focus=true), not 19.3.6.13, as expected.