### PR TITLE
Bring flycheck output inline with expected format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.11.2
+  * Enhancements
+    * Simplify `--flycheck` output to align with expected format
+
 ## v0.11.1
   * Enhancements
     * Sarif output with `--out` flag

--- a/README.md
+++ b/README.md
@@ -114,7 +114,11 @@ relative to the application root.
   * `--quiet` - Return a single line indicating number of findings.
   Otherwise, return no output if there are no findings.
 
-  * `--compact` - Minimal, single-line findings.
+  * `--compact` - Minimal, single-line findings with output colorised
+    according to confidence.
+
+  * `--flycheck` - Minimal, single-line findings that are compatible
+    with flycheck-based tooling.
 
   * `--save-config` - Generates a configuration file based on command
   line options. See [Configuration Files](#configuration-files) for more

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -278,7 +278,6 @@ defmodule Sobelow do
   def format() do
     case get_env(:format) do
       "sarif" -> "json"
-      "flycheck" -> "compact"
       format -> format
     end
   end

--- a/lib/sobelow/config/csp.ex
+++ b/lib/sobelow/config/csp.ex
@@ -141,6 +141,9 @@ defmodule Sobelow.Config.CSP do
       "compact" ->
         Print.log_compact_finding(finding)
 
+      "flycheck" ->
+        Print.log_flycheck_finding(finding)
+
       _ ->
         Sobelow.log_finding(finding)
     end

--- a/lib/sobelow/config/csrf.ex
+++ b/lib/sobelow/config/csrf.ex
@@ -77,6 +77,9 @@ defmodule Sobelow.Config.CSRF do
       "compact" ->
         Print.log_compact_finding(finding)
 
+      "flycheck" ->
+        Print.log_flycheck_finding(finding)
+
       _ ->
         Sobelow.log_finding(finding)
     end

--- a/lib/sobelow/config/csrf_route.ex
+++ b/lib/sobelow/config/csrf_route.ex
@@ -106,6 +106,9 @@ defmodule Sobelow.Config.CSRFRoute do
       "compact" ->
         Print.log_compact_finding(finding)
 
+      "flycheck" ->
+        Print.log_flycheck_finding(finding)
+
       _ ->
         Sobelow.log_finding(finding)
     end

--- a/lib/sobelow/config/cswh.ex
+++ b/lib/sobelow/config/cswh.ex
@@ -89,6 +89,9 @@ defmodule Sobelow.Config.CSWH do
       "compact" ->
         Print.log_compact_finding(finding)
 
+      "flycheck" ->
+        Print.log_flycheck_finding(finding)
+
       _ ->
         Sobelow.log_finding(finding)
     end

--- a/lib/sobelow/config/headers.ex
+++ b/lib/sobelow/config/headers.ex
@@ -75,6 +75,9 @@ defmodule Sobelow.Config.Headers do
       "compact" ->
         Print.log_compact_finding(finding)
 
+      "flycheck" ->
+        Print.log_flycheck_finding(finding)
+
       _ ->
         Sobelow.log_finding(finding)
     end

--- a/lib/sobelow/config/hsts.ex
+++ b/lib/sobelow/config/hsts.ex
@@ -67,6 +67,9 @@ defmodule Sobelow.Config.HSTS do
       "compact" ->
         Print.log_compact_finding(finding)
 
+      "flycheck" ->
+        Print.log_flycheck_finding(finding)
+
       _ ->
         Sobelow.log_finding(finding)
     end

--- a/lib/sobelow/config/https.ex
+++ b/lib/sobelow/config/https.ex
@@ -69,6 +69,9 @@ defmodule Sobelow.Config.HTTPS do
       "compact" ->
         Print.log_compact_finding(finding)
 
+      "flycheck" ->
+        Print.log_flycheck_finding(finding)
+
       _ ->
         Sobelow.log_finding(finding)
     end

--- a/lib/sobelow/config/secrets.ex
+++ b/lib/sobelow/config/secrets.ex
@@ -104,6 +104,9 @@ defmodule Sobelow.Config.Secrets do
       "compact" ->
         Print.log_compact_finding(finding)
 
+      "flycheck" ->
+        Print.log_flycheck_finding(finding)
+
       _ ->
         Sobelow.log_finding(finding)
     end

--- a/lib/sobelow/print.ex
+++ b/lib/sobelow/print.ex
@@ -4,6 +4,7 @@ defmodule Sobelow.Print do
 
   def add_finding(%Finding{} = finding) do
     finding = Finding.fetch_fingerprint(finding)
+
     case Sobelow.format() do
       "json" ->
         log_json_finding(finding)

--- a/lib/sobelow/print.ex
+++ b/lib/sobelow/print.ex
@@ -4,7 +4,6 @@ defmodule Sobelow.Print do
 
   def add_finding(%Finding{} = finding) do
     finding = Finding.fetch_fingerprint(finding)
-
     case Sobelow.format() do
       "json" ->
         log_json_finding(finding)
@@ -15,6 +14,9 @@ defmodule Sobelow.Print do
 
       "compact" ->
         log_compact_finding(finding)
+
+      "flycheck" ->
+        log_flycheck_finding(finding)
 
       _ ->
         Sobelow.log_finding(finding)
@@ -55,11 +57,7 @@ defmodule Sobelow.Print do
   end
 
   def log_compact_finding(%Finding{} = finding) do
-    details =
-      case Sobelow.get_env(:format) do
-        "flycheck" -> "#{finding.filename}:#{finding.vuln_line_no}: #{finding.type}"
-        "compact" -> "#{finding.type} - #{finding.filename}:#{finding.vuln_line_no}"
-      end
+    details = "#{finding.type} - #{finding.filename}:#{finding.vuln_line_no}"
 
     Sobelow.log_finding(%{finding | type: details})
     print_compact_finding(finding, details)
@@ -80,6 +78,23 @@ defmodule Sobelow.Print do
       end
 
     IO.puts("#{sev}[+]#{IO.ANSI.reset()} #{details}")
+  end
+
+  def log_flycheck_finding(%Finding{} = finding) do
+    details = "#{finding.filename}:#{finding.vuln_line_no}: #{finding.type}"
+
+    Sobelow.log_finding(%{finding | type: details})
+    print_flycheck_finding(finding, details)
+  end
+
+  defp print_flycheck_finding(finding, details) do
+    if Sobelow.loggable?(finding.fingerprint, finding.confidence) do
+      do_print_flycheck_finding(details, finding.confidence)
+    end
+  end
+
+  defp do_print_flycheck_finding(details, _confidence) do
+    IO.puts(details)
   end
 
   def log_json_finding(%Finding{} = finding) do

--- a/lib/sobelow/vuln.ex
+++ b/lib/sobelow/vuln.ex
@@ -68,6 +68,9 @@ defmodule Sobelow.Vuln do
       "compact" ->
         Print.log_compact_finding(finding)
 
+      "flycheck" ->
+        Print.log_flycheck_finding(finding)
+
       _ ->
         Sobelow.log_finding(finding)
     end

--- a/lib/sobelow/xss/raw.ex
+++ b/lib/sobelow/xss/raw.ex
@@ -135,6 +135,9 @@ defmodule Sobelow.XSS.Raw do
       "compact" ->
         Print.log_compact_finding(finding)
 
+      "flycheck" ->
+        Print.log_flycheck_finding(finding)
+
       _ ->
         Sobelow.log_finding(finding)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Sobelow.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/nccgroup/sobelow"
-  @version "0.11.1"
+  @version "0.11.2"
 
   def project do
     [


### PR DESCRIPTION
The output from sobelow with the `--flycheck` flag does not follow the format as output by the original Flycheck tool; it uses Sobelow's "compact" format but switches the order. This makes it incompatible with tooling that expects the output to be the same as that from the original Flycheck tool.

This PR separates `--flycheck` into it's own "full" format, consistent with that of the `--compact` flag, adds documentation for the new flag to the `README`, and increases the patch version to reflect this change.