### PR TITLE
Use SPDX ID for licenses in mixfile

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Sobelow.Mixfile do
 
   defp package() do
     [
-      licenses: ["Apache 2"],
+      licenses: ["Apache-2.0"],
       maintainers: ["Griffin Byatt"],
       links: %{
         "Changelog" => "#{@source_url}/blob/master/CHANGELOG.md",


### PR DESCRIPTION
Hex.pm recommends this, and it helps tools identify the exact license this project uses.