### PR TITLE
Add umbrella app instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ command line:
     
 ## Umbrella Apps
 
-In order to run Sobelow against all child apps within an umbrella app with a single command, you can add an alias sobelow in your root `mix.exs` file:
+In order to run Sobelow against all child apps within an umbrella app with a single command, you can add an alias for sobelow in your root `mix.exs` file:
 
 ```elixir
 defp aliases do

--- a/README.md
+++ b/README.md
@@ -201,6 +201,20 @@ This list, and other helpful information, can be found on the
 command line:
 
     $ mix help sobelow
+    
+## Umbrella Apps
+
+In order to run Sobelow against all child apps within an umbrella app with a single command, you can add an alias sobelow in your root `mix.exs` file:
+
+```elixir
+defp aliases do
+  [
+    sobelow: ["cmd mix sobelow"]
+  ]
+end
+```
+
+If you wish to use configuration files in an umbrella app, create a `.sobelow-conf` in each child application and use the `--config` flag.
 
 ## Updates
 When scanning a project, Sobelow will occasionally check for


### PR DESCRIPTION
Thanks for your work on Sobelow! 

I was searching for guidance on how to run Sobelow across a whole umbrella app at once, and I figured out how to easily do that through mix aliases. I didn't see any mention of umbrella apps in the README, and I noticed the question comes up from time to time in the issues, so I wanted to suggest this addition to the README.