### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To use Sobelow, you can add it to your application's dependencies.
 ```elixir
 def deps do
   [
-    {:sobelow, "~> 0.8", only: :dev}
+    {:sobelow, "~> 0.11", only: [:dev, :test], runtime: false}
   ]
 end
 ```


### PR DESCRIPTION
`sobelow` is often running in continuous integration pipelines and when it does, it will more often than not be in the test environment. On top of this, `sobelow` doesn't have to be started as a [runtime application](https://hexdocs.pm/mix/Mix.Tasks.Deps.html#module-dependency-definition-options), so `runtime: false` can be added as well.

Closes #120