### PR TITLE
Add support for HEEx to Sobelow.XSS.Raw

### DIFF
--- a/lib/sobelow/utils.ex
+++ b/lib/sobelow/utils.ex
@@ -51,7 +51,7 @@ defmodule Sobelow.Utils do
 
   def template_files(filepath, _directory \\ "") do
     if File.dir?(filepath) do
-      Path.wildcard(filepath <> "/**/*.html.eex")
+      Path.wildcard(filepath <> "/**/*.html.{heex,eex}")
     else
       []
     end

--- a/lib/sobelow/xss/raw.ex
+++ b/lib/sobelow/xss/raw.ex
@@ -36,11 +36,11 @@ defmodule Sobelow.XSS.Raw do
           true -> ""
         end
 
-      template_path =
+      maybe_template_path =
         (template_root <> "/templates/" <> controller <> "/" <> template <> ".eex")
         |> Utils.normalize_path()
 
-      raw_funs = templates[template_path]
+      {raw_funs, template_path} = get_rf_tp(templates, maybe_template_path)
 
       if raw_funs do
         raw_vals = Parse.get_template_vars(raw_funs.raw)
@@ -66,6 +66,15 @@ defmodule Sobelow.XSS.Raw do
         end)
       end
     end)
+  end
+
+  defp get_rf_tp(templates, template_path) do
+    if templates[template_path] do
+      {templates[template_path], template_path}
+    else
+      new_path = String.replace(template_path, "eex", "heex")
+      {templates[new_path], new_path}
+    end
   end
 
   def parse_render_def(fun) do

--- a/lib/sobelow/xss/raw.ex
+++ b/lib/sobelow/xss/raw.ex
@@ -72,7 +72,7 @@ defmodule Sobelow.XSS.Raw do
     if templates[template_path] do
       {templates[template_path], template_path}
     else
-      new_path = String.replace(template_path, "eex", "heex")
+      new_path = String.slice(template_path, 0..String.length(template_path)-4) <> "heex"
       {templates[new_path], new_path}
     end
   end


### PR DESCRIPTION
Today, if you're using `HEEx` for templates in Phoenix, and have an XSS vulnerability, Sobelow will not detect it. Tested in https://github.com/securityelixir/potion_shop 

```
@ potion_shop % mix sobelow -i SQL,Config

... SCAN COMPLETE ...

@ potion_shop % 
```

This branch:

```
@ potion_shop % mix sobelow -i SQL,Config

XSS.Raw: XSS - Low Confidence
File: lib/carafe_web/templates/potion/show.html.heex
Line: 19
Variable: review

-----------------------------------------------

... SCAN COMPLETE ...

@ potion_shop % 
```

When testing this PR, I ran into a problem where this branch (master) does not run locally, it just prints the current version of Sobelow and exits. To get it running again, go to `lib/mix/tasks/sobelow.ex`, `line 185` and comment out:

```
+      #!is_nil(version) ->
+      #  Sobelow.version()
```

