### PR TITLE
--version hotfix

### DIFF
--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -182,7 +182,7 @@ defmodule Mix.Tasks.Sobelow do
       !is_nil(details) ->
         Sobelow.details()
 
-      !is_nil(version) ->
+      version ->
         Sobelow.version()
 
       true ->

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -248,7 +248,8 @@ defmodule Sobelow do
       out: get_env(:out),
       threshold: get_env(:threshold),
       ignore: get_env(:ignored),
-      ignore_files: get_env(:ignored_files)
+      ignore_files: get_env(:ignored_files),
+      version: get_env(:version)
     ]
 
     yes? =


### PR DESCRIPTION
Fixed logic error to prevent only vsn output when running `mix sobelow` (as brought up in https://github.com/nccgroup/sobelow/pull/123) and `--version` boolean is now being added to `.sobelow-conf` file when saved.