### PR TITLE
Macro.to_string/2 Deprecation

### DIFF
--- a/lib/sobelow/print.ex
+++ b/lib/sobelow/print.ex
@@ -289,16 +289,6 @@ defmodule Sobelow.Print do
     IO.puts(func_string)
   end
 
-  def print_highlighted(string, ast, find) do
-    case find do
-      ^ast ->
-        IO.ANSI.light_magenta() <> string <> IO.ANSI.reset()
-
-      _ ->
-        if is_nil(string), do: "", else: string
-    end
-  end
-
   defp maybe_highlight(string, ast, var) do
     if is_fun_with_var?(ast, var) do
       IO.ANSI.light_magenta() <> string <> IO.ANSI.reset()

--- a/lib/sobelow/xss/raw.ex
+++ b/lib/sobelow/xss/raw.ex
@@ -72,7 +72,7 @@ defmodule Sobelow.XSS.Raw do
     if templates[template_path] do
       {templates[template_path], template_path}
     else
-      new_path = String.slice(template_path, 0..String.length(template_path)-4) <> "heex"
+      new_path = String.slice(template_path, 0..(String.length(template_path) - 4)) <> "heex"
       {templates[new_path], new_path}
     end
   end


### PR DESCRIPTION
Resolves https://github.com/nccgroup/sobelow/issues/115

- Restructured `print_code()` to use Macro.prewalk/3 (First of two offending functions)
- Removed unused function (Second of two offending functions)
  - I did not see the function (or it's associated private functions) being used anywhere and I did not know how best to test it since I could not determine what its purpose was for - so I opted to just remove it rather than restructure the code as I previously did.
  - If this leads to trouble down the line, we can always revisit and reimplement with a new method similar to `print_code()`