### PR TITLE
Remove CAStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.12.2
+  * Bug fixes
+    * Removed `:castore` and introduced `:verify_none` to quiet warning and unblock escript usage, see [#133](https://github.com/nccgroup/sobelow/issues/133) for more context on why this is necessary
+
 ## v0.12.1
   * Bug fixes
     * Lowered required version of `:castore` to remove upgrade path issues

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -548,14 +548,12 @@ defmodule Sobelow do
 
     url = 'https://sobelow.io/version'
 
-    # Uses CAStore since we cannot use exclusively use OTP 25+ yet
-    # cacertfile = CAStore.file_path() |> String.to_charlist()
-
     http_options = [
       ssl: [
-        # switch to :verify_peer when we can
         verify: :verify_none
-        # cacertfile: cacertfile
+        # We cannot use exclusively use OTP 25+ yet, but when we can - uncomment the following few lines
+        # verify: :verify_peer,
+        # cacertfile: :public_key.cacerts_get()
       ],
       timeout: 10000
     ]

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -549,12 +549,13 @@ defmodule Sobelow do
     url = 'https://sobelow.io/version'
 
     # Uses CAStore since we cannot use exclusively use OTP 25+ yet
-    cacertfile = CAStore.file_path() |> String.to_charlist()
+    # cacertfile = CAStore.file_path() |> String.to_charlist()
 
     http_options = [
       ssl: [
-        verify: :verify_peer,
-        cacertfile: cacertfile
+        # switch to :verify_peer when we can
+        verify: :verify_none
+        # cacertfile: cacertfile
       ],
       timeout: 10000
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Sobelow.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/nccgroup/sobelow"
-  @version "0.12.1"
+  @version "0.12.2"
 
   def project do
     [
@@ -29,7 +29,6 @@ defmodule Sobelow.Mixfile do
     [
       {:ex_doc, "~> 0.20", only: :dev},
       {:jason, "~> 1.0"}
-      # {:castore, ">= 0.0.0"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,8 +28,8 @@ defmodule Sobelow.Mixfile do
   defp deps do
     [
       {:ex_doc, "~> 0.20", only: :dev},
-      {:jason, "~> 1.0"},
-      {:castore, ">= 0.0.0"}
+      {:jason, "~> 1.0"}
+      # {:castore, ">= 0.0.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,4 @@
 %{
-  "castore": {:hex, :castore, "1.0.0", "c25cd0794c054ebe6908a86820c8b92b5695814479ec95eeff35192720b71eec", [:mix], [], "hexpm", "577d0e855983a97ca1dfa33cbb8a3b6ece6767397ffb4861514343b078fc284b"},
-  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm", "e3be2bc3ae67781db529b80aa7e7c49904a988596e2dbff897425b48b3581161"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.29", "149d50dcb3a93d9f3d6f3ecf18c918fb5a2d3c001b5d3305c926cddfbd33355b", [:mix], [], "hexpm", "4902af1b3eb139016aed210888748db8070b8125c2342ce3dcae4f38dcc63503"},
   "ex_doc": {:hex, :ex_doc, "0.29.1", "b1c652fa5f92ee9cf15c75271168027f92039b3877094290a75abcaac82a9f77", [:mix], [{:earmark_parser, "~> 1.4.19", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "b7745fa6374a36daf484e2a2012274950e084815b936b1319aeebcf7809574f6"},
   "jason": {:hex, :jason, "1.4.0", "e855647bc964a44e2f67df589ccf49105ae039d4179db7f6271dfd3843dc27e6", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "79a3791085b2a0f743ca04cec0f7be26443738779d09302e01318f97bdb82121"},


### PR DESCRIPTION
Moved SSL to `:verify_none` to avoid CAStore dependency temporarily, addresses https://github.com/nccgroup/sobelow/issues/133 and associated [sobelow/action issue](https://github.com/sobelow/action/issues/1)