### PR TITLE
Upgrade to Elixir 1.15

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -33,6 +33,8 @@ jobs:
             otp: 25.1
           - elixir: '1.14.x'
             otp: 25.1
+          - elixir: '1.15.x'
+            otp: 26.0
 
     steps:
     - name: Setup Elixir
@@ -54,11 +56,11 @@ jobs:
       run: mix hex.audit
 
     - name: Check Formatting
-      if: ${{ matrix.elixir == '1.14.x' }} # we only care about formatting for latest version of Elixir
+      if: ${{ matrix.elixir == '1.15.x' }} # we only care about formatting for latest version of Elixir
       run: mix format --check-formatted
 
     - name: Compiles w/o Warnings
-      if: ${{ matrix.elixir == '1.14.x' }} # we only care about warnings for latest version of Elixir
+      if: ${{ matrix.elixir == '1.15.x' }} # we only care about warnings for latest version of Elixir
       run: mix compile --warnings-as-errors
 
     - name: Credo

--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -169,6 +169,11 @@ defmodule Mix.Tasks.Sobelow do
 
     save_config = Keyword.get(opts, :save_config)
 
+    if function_exported?(Mix, :ensure_application!, 1) do
+      Mix.ensure_application!(:ssl)
+      Mix.ensure_application!(:inets)
+    end
+
     cond do
       diff ->
         run_diff(argv)

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -526,7 +526,7 @@ defmodule Sobelow do
 
       {timestamp, _} =
         case :file.read_line(iofile) do
-          {:ok, 'sobelow-' ++ timestamp} -> to_string(timestamp) |> Integer.parse()
+          {:ok, ~c"sobelow-" ++ timestamp} -> to_string(timestamp) |> Integer.parse()
           _ -> file_error()
         end
 
@@ -546,7 +546,7 @@ defmodule Sobelow do
     {:ok, _} = Application.ensure_all_started(:inets)
     {:ok, _} = :inets.start(:httpc, [{:profile, :sobelow}])
 
-    url = 'https://sobelow.io/version'
+    url = ~c"https://sobelow.io/version"
 
     http_options = [
       ssl: [

--- a/test/fixtures/utils/config.exs
+++ b/test/fixtures/utils/config.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
 config :test,
-  security_option: 'option'
+  security_option: ~c"option"

--- a/test/log_test.exs
+++ b/test/log_test.exs
@@ -4,7 +4,7 @@ defmodule SobelowTest.LogTest do
 
   # log_json_finding(line_no, filename, fun_name, var, severity, type)
   test "Log JSON finding with function as function name" do
-    output = """
+    output = Jason.decode!("""
     {
       "findings": {
         "high_confidence": [
@@ -21,7 +21,7 @@ defmodule SobelowTest.LogTest do
       "sobelow_version": "1.0.0",
       "total_findings": 1
     }
-    """
+    """)
 
     FindingLog.start_link()
     Fingerprint.start_link()
@@ -35,6 +35,6 @@ defmodule SobelowTest.LogTest do
 
     Sobelow.log_finding(finding, %Sobelow.Finding{confidence: :high})
 
-    assert FindingLog.json("1.0.0") <> "\n" == output
+    assert Jason.decode!(FindingLog.json("1.0.0")) == output
   end
 end

--- a/test/log_test.exs
+++ b/test/log_test.exs
@@ -4,24 +4,25 @@ defmodule SobelowTest.LogTest do
 
   # log_json_finding(line_no, filename, fun_name, var, severity, type)
   test "Log JSON finding with function as function name" do
-    output = Jason.decode!("""
-    {
-      "findings": {
-        "high_confidence": [
-          {
-            "file": "file.ex",
-            "line": 1,
-            "type": "N/A",
-            "variable": "var"
-          }
-        ],
-        "low_confidence": [],
-        "medium_confidence": []
-      },
-      "sobelow_version": "1.0.0",
-      "total_findings": 1
-    }
-    """)
+    output =
+      Jason.decode!("""
+      {
+        "findings": {
+          "high_confidence": [
+            {
+              "file": "file.ex",
+              "line": 1,
+              "type": "N/A",
+              "variable": "var"
+            }
+          ],
+          "low_confidence": [],
+          "medium_confidence": []
+        },
+        "sobelow_version": "1.0.0",
+        "total_findings": 1
+      }
+      """)
 
     FindingLog.start_link()
     Fingerprint.start_link()


### PR DESCRIPTION
Inets and SSL needs to be loaded in Elixir 1.15 due to code load changes. This is identical to how it was resolved in tailwind: https://github.com/phoenixframework/tailwind/commit/68185c77c7f83c6b634cc7624b19633cb61b83d2

 I believe the JSON test fails due to changes for key order in map with OTP 26, so I'm comparing maps rather than encoded strings.