### PR TITLE
Use trunc when idx is given as a float instead of an int

### DIFF
--- a/lib/sobelow/parse.ex
+++ b/lib/sobelow/parse.ex
@@ -455,7 +455,7 @@ defmodule Sobelow.Parse do
   end
 
   defp create_fun_cap(fun, meta, idx) when is_number(idx) do
-    opts = Enum.map(1..idx, fn i -> {:&, [], [i]} end)
+    opts = Enum.map(1..trunc(idx), fn i -> {:&, [], [i]} end)
     {fun, meta, opts}
   end
 


### PR DESCRIPTION
Truncating the value of `idx` seems to fix the ranges issue - https://github.com/nccgroup/sobelow/issues/145

You could just add this to https://github.com/nccgroup/sobelow/pull/146 