### PR TITLE
Include fingerprint in print and JSON format output

### DIFF
--- a/lib/sobelow/print.ex
+++ b/lib/sobelow/print.ex
@@ -36,6 +36,7 @@ defmodule Sobelow.Print do
     IO.puts(finding_line(finding.vuln_line_no))
     maybe_print_finding_fun_metadata(finding.fun_name, finding.fun_line_no)
     IO.puts(finding_variable(finding.vuln_variable))
+    IO.puts(finding_fingerprint(finding))
     maybe_print_code(finding.fun_source, finding.vuln_source)
     IO.puts(finding_break())
   end
@@ -103,7 +104,8 @@ defmodule Sobelow.Print do
       type: finding.type,
       file: finding.filename,
       line: finding.vuln_line_no,
-      variable: finding.vuln_variable
+      variable: finding.vuln_variable,
+      fingerprint: finding.fingerprint
     ]
 
     Sobelow.log_finding(json_finding, finding)
@@ -161,6 +163,10 @@ defmodule Sobelow.Print do
 
   def finding_break do
     "\n-----------------------------------------------\n"
+  end
+
+  def finding_fingerprint(%Finding{} = finding) do
+    "Fingerprint: #{finding.fingerprint}"
   end
 
   def maybe_print_code(fun, finding) do

--- a/test/print_test.exs
+++ b/test/print_test.exs
@@ -25,6 +25,8 @@ defmodule SobelowTest.PrintTest do
       CodeModule.run(ast, @metafile)
     end
 
-    assert capture_io(run_test) =~ "Code Execution in `Code.eval_string` - Medium Confidence"
+    output = capture_io(run_test)
+    assert output =~ "Code Execution in `Code.eval_string` - Medium Confidence"
+    assert output =~ "Fingerprint: 4B5AA54E7C16D1D9876E9118B84CB6CE"
   end
 end


### PR DESCRIPTION
This fingerprint allows selectively targeting violations using a skip file.

**Use Case:** I want to selectively skip violations with a written explanation as to why it's a false positive. I want to keep this in a single central file instead of using the comment-based skip approach.