### PR TITLE
Added File.stream/.stream! to Traversal check

### DIFF
--- a/lib/sobelow/traversal/file_module.ex
+++ b/lib/sobelow/traversal/file_module.ex
@@ -33,7 +33,9 @@ defmodule Sobelow.Traversal.FileModule do
     :mkdir,
     :mkdir!,
     :mkdir_p,
-    :mkdir_p!
+    :mkdir_p!,
+    :stream,
+    :stream!
   ]
   @double_file_funcs [:cp, :copy, :cp!, :copy!, :cp_r, :cp_r!, :ln, :ln!, :ln_s, :ln_s!]
 

--- a/test/traversal/file_module_test.exs
+++ b/test/traversal/file_module_test.exs
@@ -3,7 +3,7 @@ defmodule SobelowTest.Traversal.FileModuleTest do
   import Sobelow, only: [is_vuln?: 1]
   alias Sobelow.Traversal.FileModule
 
-  @evil_funcs [:read, :read!, :write, :write!, :rm, :rm!, :rm_rf]
+  @evil_funcs [:read, :read!, :write, :write!, :rm, :rm!, :rm_rf, :stream, :stream!]
 
   @double_evil_funcs [:cp, :cp!, :cp_r, :cp_r!, :ln, :ln!, :ln_s, :ln_s!]
 


### PR DESCRIPTION
stream functions were missing from the File traversal checks. This adds them. Checking for stream is as important as open.