### PR TITLE
fix is_endpoint? error in main

### DIFF
--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -327,7 +327,7 @@ defmodule Sobelow do
           meta_file.router? ->
             Map.update!(acc, :routers, &[meta_file.file_path | &1])
 
-          meta_file.endpoint? ->
+          meta_file.is_endpoint? ->
             Map.update!(acc, :endpoints, &[meta_file.file_path | &1])
 
           true ->


### PR DESCRIPTION
** (KeyError) key :endpoint? not found in: %{controller?: false, def_funs: [], file_path: "<REDACTED>", filename: "lib/blitz_cms_api.ex", is_endpoint?: false, router?: false}. Did you mean:

      * :is_endpoint?

    (sobelow 0.13.0) lib/sobelow.ex:330: anonymous fn/2 in Sobelow.get_phoenix_files/2
    (elixir 1.14.2) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
    (sobelow 0.13.0) lib/sobelow.ex:325: Sobelow.get_phoenix_files/2
    (sobelow 0.13.0) lib/sobelow.ex:74: Sobelow.run/0
    (mix 1.14.2) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (mix 1.14.2) lib/mix/cli.ex:84: Mix.CLI.run_task/2