### PR TITLE
ignore runtime config in hsts check

### DIFF
--- a/lib/sobelow/config/hsts.ex
+++ b/lib/sobelow/config/hsts.ex
@@ -14,20 +14,23 @@ defmodule Sobelow.Config.HSTS do
 
   @uid 8
   @finding_type "Config.HSTS: HSTS Not Enabled"
+  @ignored_files ["runtime.exs"]
 
   use Sobelow.Finding
 
   def run(dir_path, configs) do
     Enum.each(configs, fn conf ->
-      path = dir_path <> conf
+      unless Enum.member?(@ignored_files, conf) do
+        path = dir_path <> conf
 
-      Config.get_configs_by_file(:https, path)
-      |> handle_https(path)
+        Config.get_configs_by_file(:https, path)
+        |> handle_https(path)
+      end
     end)
   end
 
   defp handle_https(opts, file) do
-    # If HTTPS configs were found in any config file and there
+    # If HTTPS configs were found in any compile-time config file and there
     # are no accompanying HSTS configs, add an HSTS finding.
     if length(opts) > 0 && Enum.empty?(Config.get_configs(:force_ssl, file)) do
       add_finding(file)

--- a/test/config/hsts_test.exs
+++ b/test/config/hsts_test.exs
@@ -1,0 +1,27 @@
+defmodule SobelowTest.Config.HstsTest do
+  use ExUnit.Case
+  alias Sobelow.Config.HSTS
+
+  setup do
+    Application.put_env(:sobelow, :format, "json")
+    Sobelow.Fingerprint.start_link()
+    Sobelow.FindingLog.start_link()
+
+    :ok
+  end
+
+  test "complains when force_ssl is missing in prod.exs" do
+    HSTS.run("./test/fixtures/hsts/", ["missing_prod.exs"])
+    assert Sobelow.FindingLog.json("1") =~ "Config.HSTS: HSTS Not Enabled"
+  end
+
+  test "does not complain when force_ssl is present in prod.exs" do
+    HSTS.run("./test/fixtures/hsts/", ["present_prod.exs"])
+    refute Sobelow.FindingLog.json("1") =~ "Config.HSTS: HSTS Not Enabled"
+  end
+
+  test "does not complain when force_ssl is missing in runtime.exs" do
+    HSTS.run("./test/fixtures/hsts/", ["runtime.exs"])
+    refute Sobelow.FindingLog.json("1") =~ "Config.HSTS: HSTS Not Enabled"
+  end
+end

--- a/test/fixtures/hsts/missing_prod.exs
+++ b/test/fixtures/hsts/missing_prod.exs
@@ -1,0 +1,4 @@
+use Config
+
+config :phoenix_app,
+  https: []

--- a/test/fixtures/hsts/present_prod.exs
+++ b/test/fixtures/hsts/present_prod.exs
@@ -1,0 +1,5 @@
+use Config
+
+config :phoenix_app,
+  https: [],
+  force_ssl: [hsts: true]

--- a/test/fixtures/hsts/runtime.exs
+++ b/test/fixtures/hsts/runtime.exs
@@ -1,0 +1,4 @@
+use Config
+
+config :phoenix_app,
+  https: []


### PR DESCRIPTION
I was going through https://hexdocs.pm/phoenix/using_ssl.html to set up SSL for a Phoenix service.
According to the documentation:
> It is important to note that force_ssl: is a compile time config, so it normally is set in prod.exs, it will not work when set from runtime.exs.

Sobelow currently warns when `runtime.exs` contains `https` settings but no `force_ssl`.
This PR suggests to ignore the `runtime.exs` file when checking HSTS.
