### PR TITLE
Fix possible KeyError

### DIFF
--- a/lib/sobelow/finding_log.ex
+++ b/lib/sobelow/finding_log.ex
@@ -110,7 +110,7 @@ defmodule Sobelow.FindingLog do
     [mod, _] = String.split(finding.type, ":", parts: 2)
 
     %{
-      ruleId: Sobelow.get_mod(mod).id,
+      ruleId: Sobelow.get_mod(mod) |> get_in([:id]),
       message: %{
         text: finding.type
       },


### PR DESCRIPTION
I noticed this while upgrading to Elixir 1.18 from the new type system (see below). `Sobelow.get_mod/1` can return `nil`, so we should account for that.

```
     warning: expected a map or struct when accessing .id in expression:

         Sobelow.get_mod(mod).id

     but got type:

         dynamic(
           Sobelow.CI or Sobelow.CI.OS or Sobelow.CI.System or Sobelow.Config or Sobelow.Config.CSP or
             Sobelow.Config.CSRF or Sobelow.Config.CSRFRoute or Sobelow.Config.CSWH or Sobelow.Config.HSTS or
             Sobelow.Config.HTTPS or Sobelow.Config.Headers or Sobelow.Config.Secrets or Sobelow.DOS or
             Sobelow.DOS.BinToAtom or Sobelow.DOS.ListToAtom or Sobelow.DOS.StringToAtom or Sobelow.Misc or
             Sobelow.Misc.BinToTerm or Sobelow.Misc.FilePath or Sobelow.RCE or Sobelow.RCE.CodeModule or
             Sobelow.RCE.EEx or Sobelow.SQL or Sobelow.SQL.Query or Sobelow.SQL.Stream or Sobelow.Traversal or
             Sobelow.Traversal.FileModule or Sobelow.Traversal.SendDownload or Sobelow.Traversal.SendFile or
             Sobelow.Vuln or Sobelow.Vuln.Coherence or Sobelow.Vuln.CookieRCE or Sobelow.Vuln.Ecto or
             Sobelow.Vuln.HeaderInject or Sobelow.Vuln.PlugNull or Sobelow.Vuln.Redirect or Sobelow.XSS or
             Sobelow.XSS.ContentType or Sobelow.XSS.HTML or Sobelow.XSS.Raw or Sobelow.XSS.SendResp or nil
         )

     where "mod" was given the type:

         # type: dynamic()
         # from: lib/sobelow/finding_log.ex:110:14
         [mod, _] = String.split(finding.type, ":", parts: 2)

     hint: "var.field" (without parentheses) means "var" is a map() while "var.fun()" (with parentheses) means "var" is an atom()

     typing violation found at:
     │
 113 │       ruleId: Sobelow.get_mod(mod).id,
     │                                    ~
     │
     └─ lib/sobelow/finding_log.ex:113:36: Sobelow.FindingLog.format_sarif/1
```