### PR TITLE
Fixed typespec-warning

### DIFF
--- a/lib/sobelow/finding_log.ex
+++ b/lib/sobelow/finding_log.ex
@@ -108,6 +108,8 @@ defmodule Sobelow.FindingLog do
 
   defp format_sarif(finding) do
     [mod, _] = String.split(finding.type, ":", parts: 2)
+    mod_struct = Sobelow.get_mod(mod)
+    rule_id = if is_struct(mod_struct), do: mod_struct.id, else: nil
 
     %{
       ruleId: Sobelow.get_mod(mod).id,


### PR DESCRIPTION
Fix typespec warning in finding_log.ex
The current implementation attempts to access the id field directly from Sobelow.get_mod(mod) result, but the typespec indicates this function might return something that's not a struct. This causes a warning during compilation.
This PR adds a safety check using is_struct/1 to ensure we only access the id field when we have a proper struct, falling back to nil otherwise.
Before:
ruleId: Sobelow.get_mod(mod).id
After:
mod_struct = Sobelow.get_mod(mod)
rule_id = if is_struct(mod_struct), do: mod_struct.id, else: nil

This maintains the same functionality while resolving the typespec warning during compilation.

The warning on our code was:
==> sobelow
     warning: expected a map or struct when accessing .id in expression:

         Sobelow.get_mod(mod).id

     but got type:

         dynamic(
           Sobelow.CI or Sobelow.CI.OS or Sobelow.CI.System or Sobelow.Config or Sobelow.Config.CSP or
             Sobelow.Config.CSRF or Sobelow.Config.CSRFRoute or Sobelow.Config.CSWH or Sobelow.Config.HSTS or
             Sobelow.Config.HTTPS or Sobelow.Config.Headers or Sobelow.Config.Secrets or Sobelow.DOS or
             Sobelow.DOS.BinToAtom or Sobelow.DOS.ListToAtom or Sobelow.DOS.StringToAtom or Sobelow.Misc or
             Sobelow.Misc.BinToTerm or Sobelow.Misc.FilePath or Sobelow.RCE or Sobelow.RCE.CodeModule or
             Sobelow.RCE.EEx or Sobelow.SQL or Sobelow.SQL.Query or Sobelow.SQL.Stream or Sobelow.Traversal or
             Sobelow.Traversal.FileModule or Sobelow.Traversal.SendDownload or Sobelow.Traversal.SendFile or
             Sobelow.Vuln or Sobelow.Vuln.Coherence or Sobelow.Vuln.CookieRCE or Sobelow.Vuln.Ecto or
             Sobelow.Vuln.HeaderInject or Sobelow.Vuln.PlugNull or Sobelow.Vuln.Redirect or Sobelow.XSS or
             Sobelow.XSS.ContentType or Sobelow.XSS.HTML or Sobelow.XSS.Raw or Sobelow.XSS.SendResp or nil
         )

     where "mod" was given the type:

         # type: dynamic()
         # from: lib/sobelow/finding_log.ex:110:14
         [mod, _] = String.split(finding.type, ":", parts: 2)

     hint: "var.field" (without parentheses) means "var" is a map() while "var.fun()" (with parentheses) means "var" is an atom()

     typing violation found at:
     │
 113 │       ruleId: Sobelow.get_mod(mod).id,
     │                                    ~
     │
     └─ lib/sobelow/finding_log.ex:113:36: Sobelow.FindingLog.format_sarif/1