### PR TITLE
Add System.shell command injection

### DIFF
--- a/lib/sobelow/ci/system.ex
+++ b/lib/sobelow/ci/system.ex
@@ -1,6 +1,6 @@
 defmodule Sobelow.CI.System do
   @moduledoc """
-  # Command Injection in `System.cmd`
+  # Command Injection via `System`
 
   This submodule of the `CI` module checks for Command Injection
   vulnerabilities through usage of the `System.cmd` function.
@@ -12,7 +12,7 @@ defmodule Sobelow.CI.System do
       $ mix sobelow -i CI.System
   """
   @uid 2
-  @finding_type "CI.System: Command Injection in `System.cmd`"
+  @finding_type "CI.System: Command Injection via `System` function"
 
   use Sobelow.Finding
 
@@ -22,9 +22,17 @@ defmodule Sobelow.CI.System do
     Finding.init(@finding_type, meta_file.filename, confidence)
     |> Finding.multi_from_def(fun, parse_def(fun))
     |> Enum.each(&Print.add_finding(&1))
+
+    Finding.init(@finding_type, meta_file.filename, confidence)
+    |> Finding.multi_from_def(fun, parse_def_shell(fun))
+    |> Enum.each(&Print.add_finding(&1))
   end
 
   def parse_def(fun) do
     Parse.get_fun_vars_and_meta(fun, 0, :cmd, [:System])
+  end
+
+  def parse_def_shell(fun) do
+    Parse.get_fun_vars_and_meta(fun, 0, :shell, [:System])
   end
 end


### PR DESCRIPTION
`System.shell` was added in Elixir 1.12 - https://hexdocs.pm/elixir/1.18.1/System.html#shell/2

This PR modifies the existing `System.cmd` check to add `shell`. Tested on Potion Shop - https://github.com/securityelixir/potion_shop with the following change:

```
defmodule CarafeWeb.PotionController do
   ...

  def show(conn, %{"id" => id}) do
    System.shell(id)
```

```CI.System: Command Injection via `System` function - lib/carafe_web/controllers/potion_controller.ex:19```

